### PR TITLE
Release 2.3.1

### DIFF
--- a/sm64-livesplit-autosplitter.asl
+++ b/sm64-livesplit-autosplitter.asl
@@ -603,7 +603,8 @@ startup {
 			stageIndex_old != stageIndex_current &&
 			(
 				(STAGE_INDEXES[stageIndex_old] && CASTLE_STAGE_INDEXES[stageIndex_current]) ||
-				(STAGE_INDEXES[stageIndex_old] && BOWSER_FIGHT_STAGE_INDEXES[stageIndex_current])
+				(STAGE_INDEXES[stageIndex_old] && BOWSER_FIGHT_STAGE_INDEXES[stageIndex_current]) ||
+				(BOWSER_FIGHT_STAGE_INDEXES[stageIndex_old] && CASTLE_STAGE_INDEXES[stageIndex_current])
 			)
 		);
 	};

--- a/sm64-livesplit-autosplitter.asl
+++ b/sm64-livesplit-autosplitter.asl
@@ -1177,10 +1177,9 @@ startup {
 		}
 
 		// Return the result of splitting conditions check, vars are reset in onSplit to avoid duplicate splitting.
-		// FIXME: This should check actual fades using isStageFadeIn and isStageFadeOut to avoid bad VC split in 120. To test later.
 		return (
 			splitConditions.isSplittingImmediately ||
-			(splitConditions.isSplittingOnFade && stageIndex_old != stageIndex_current)
+			(splitConditions.isSplittingOnFade && (isStageFadeIn(stageIndex_old, stageIndex_current) || isStageFadeOut(stageIndex_old, stageIndex_current)))
 		);
 	};
 


### PR DESCRIPTION
This release introduces the following bug fixes and new features:

- [bugfix] Fix stage classification for Metal Cap stage.
- [bugfix] Fixes invalid splitting when opening moat door.
- [bugfix] Fixes parsing of split name when sub splits are used.
- [bugfix] Fixes handing of usamune's non-stop mode which is different from the GameShark code distributed.
- [bugfix] Fixes key grab splitting logic for non-stop.
- [new feature] Introduces start on file select in addition to start on logo's first frame.