### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ support ROM Hacks.
 - If a split is marked with ``[manual]`` then you are responsible for splitting.
 - Bowser stage and key can also be configured using ``[key]``, ``[bowser]`` or ``[pipe]``. Also available, is ``[mips]``.
 - **Importantly**: all instructions can be merged into one block comma separated, eg. ``[26,immediate,noreset]``
+- To force splitting to only happen on final star grab (eg. for Bingo splits), use ``[final-star-grab]``
 
 ### Hiding Auto-Splitter Instructions.
 
@@ -167,7 +168,8 @@ to port these changes every time you upgrade the script.
 RTA Mode
 --------
 
-RTA mode is enabled when "RTA" is present in the category name for the splits. It adds reset and start conditions, with usamune ROM in mind.
+RTA mode is enabled when keyword ``run-mode=rta`` is present in the category name for the splits. It adds reset and start conditions,
+with usamune ROM in mind.
 
 Reset: If star count decreases, the timer is reset.
 
@@ -178,6 +180,18 @@ Additional start conditions:
 - A key door is touched.
 	
 Splitting conditions (incl. last split) are identical.
+
+Non-Stop
+--------
+
+Non-Stop mode is supported similarly to vanilla runs, one thing to note is that ``[immediate]`` works with non-stop and can be used
+to do very detailed splitting.
+
+RomHack Support
+---------------
+
+RomHack support is limited with this splitter as it is trying to keep accuracy as high as possible for vanilla, but adding
+the keyword ``run-mode=romhack`` to first segment will disable some checks which can help splitting on fade-out.
 
 ## Examples (with Usamune ROM Interaction)
 

--- a/sm64-livesplit-autosplitter.asl
+++ b/sm64-livesplit-autosplitter.asl
@@ -1,4 +1,4 @@
-// Version: 2.3.1
+// Version: 2.3.2beta
 
 // Code: https://github.com/n64decomp/sm64/
 // Address map: https://github.com/SM64-TAS-ABC/STROOP/tree/Development/STROOP/Mappings

--- a/sm64-livesplit-autosplitter.asl
+++ b/sm64-livesplit-autosplitter.asl
@@ -1,4 +1,4 @@
-// Version: 2.3.2beta
+// Version: 3.0.0
 
 // Code: https://github.com/n64decomp/sm64/
 // Address map: https://github.com/SM64-TAS-ABC/STROOP/tree/Development/STROOP/Mappings
@@ -349,7 +349,7 @@ startup {
 	System.Text.RegularExpressions.Regex ENTRY = new System.Text.RegularExpressions.Regex(@"^entry=(?<stageID>(\w+|\d+))$");
 	System.Text.RegularExpressions.Regex EXIT = new System.Text.RegularExpressions.Regex(@"^exit=(?<stageID>(\w+|\d+))$");
 	System.Text.RegularExpressions.Regex STAR_DOOR = new System.Text.RegularExpressions.Regex(@"^star-door=(?<starCount>(8|30|50|70))$");
-	System.Text.RegularExpressions.Regex MODE = new System.Text.RegularExpressions.Regex(@"^mode=(?<modeName>(romhack|rta))$");
+	System.Text.RegularExpressions.Regex MODE = new System.Text.RegularExpressions.Regex(@"^run-mode=(?<modeName>(romhack|rta))$");
 
 	// TODO(#6): AutoSplitter64 compatibility
 	// System.Text.RegularExpressions.Regex XCAM_COUNT = new System.Text.RegularExpressions.Regex(@"^xcam=(?<count>\d+)$");

--- a/sm64-livesplit-autosplitter.asl
+++ b/sm64-livesplit-autosplitter.asl
@@ -247,9 +247,9 @@ startup {
 	int SPLIT_TYPE_MIPS_CLIP = 4;
 	int SPLIT_TYPE_STAR_GRAB = 5;
 	int SPLIT_TYPE_STAR_DOOR_ENTRY = 6;
-
 	int SPLIT_TYPE_STAGE_ENTRY = 7;
 	int SPLIT_TYPE_STAGE_EXIT = 8;
+	int SPLIT_TYPE_FINAL_STAR_GRAB = 9;
 
 	// Constant values used within the code.
 	uint ACT_STAR_DANCE_EXIT = 0x1302;
@@ -807,6 +807,10 @@ startup {
 		case "mips":
 			splitConfig.type = SPLIT_TYPE_MIPS_CLIP;
 			break;
+
+		case "final-star-grab":
+			splitConfig.type = SPLIT_TYPE_FINAL_STAR_GRAB;
+			break;
 		};
 	};
 
@@ -1142,7 +1146,10 @@ startup {
 
 		// This is the last split and we are getting the last star, split immediately.
 		addImmediateSplittingCondition(
-			varsD.settings.currentSplitIndex == varsD.settings.splitCount - 1 &&
+			(
+				splitConfig.type == SPLIT_TYPE_FINAL_STAR_GRAB ||
+				varsD.settings.currentSplitIndex == varsD.settings.splitCount - 1
+			) &&
 			animation_old != animation_current &&
 			animation_current == ACT_JUMBO_STAR_CUTSCENE
 		);

--- a/sm64-livesplit-autosplitter.asl
+++ b/sm64-livesplit-autosplitter.asl
@@ -72,7 +72,7 @@ startup {
 		List<string[]> result = new List<string[]>();
 
 		foreach (string phrase in phrases) {
-			string[] words = phrase.Split(' ');
+			string[] words = phrase.ToLower().Split(' ');
 			result.Add(words);
 		}
 
@@ -114,7 +114,7 @@ startup {
 		"basement",
 	});
 
-	// MIPS_CLIP_KEYWORDS:
+	// MIPS_CLIP_KEYWORDS: Any split name containing these keywords will split on DDD entry (when entering XCAM).
 	List<string[]> MIPS_CLIP_KEYWORDS = buildKeywords(new string[] {
 		"mips clip",
 	});
@@ -381,10 +381,6 @@ startup {
 	Func<ExpandoObject> initSplitConditionsData = delegate() {
 		dynamic data = new ExpandoObject();
 
-		// TODO(#6): AutoSplitter64 compatibility
-		// data.doorXCamCount = 0;
-		// data.doorXCamState = false;
-
 		data.isSplittingOnFade = false;
 		data.isSplittingImmediately = false;
 
@@ -479,9 +475,6 @@ startup {
 		result += string.Format("    varsD.data.splitConfig.isForcedFade = {0}\n", varsD.data.splitConfig.isForcedFade);
 		result += string.Format("    varsD.data.splitConfig.isForcedImmediate = {0}\n", varsD.data.splitConfig.isForcedImmediate);
 		result += "\n";
-		// TODO(#6): AutoSplitter64 compatibility
-		// result += string.Format("    varsD.data.splitConditions.doorXCamCount = {0}\n", varsD.data.splitConditions.doorXCamCount);
-		// result += string.Format("    varsD.data.splitConditions.doorXCamState = {0}\n", varsD.data.splitConditions.doorXCamState);
 		result += string.Format("    varsD.data.splitConditions.isSplittingOnFade = {0}\n", varsD.data.splitConditions.isSplittingOnFade);
 		result += string.Format("    varsD.data.splitConditions.isSplittingImmediately = {0}\n", varsD.data.splitConditions.isSplittingImmediately);
 		result += "\n";
@@ -687,7 +680,6 @@ startup {
 			string firstWord = wantedPhrase[0];
 			int wordCount = wantedPhrase.Length;
 
-
 			int startIdx = 0;
 			while (startIdx != -1) {
 				startIdx = wordsLst.IndexOf(firstWord, startIdx);
@@ -765,14 +757,6 @@ startup {
 			splitConfig.type = SPLIT_TYPE_STAR_DOOR_ENTRY;
 			splitConfig.starDoorID = parseStarDoorID(starDoorMatch[0].Groups["starCount"].Value);
 		}
-
-		// TODO(#6): AutoSplitter64 compatibility
-		// System.Text.RegularExpressions.MatchCollection doorXCamMatch = DOOR_XCAM_COUNT.Matches(val);
-		// if (doorXCamMatch.Count != 0) {
-		// 	splitConfig.doorXCamCountRequirement = Convert.ToInt32(doorXCamMatch[0].Groups["count"].Value);
-		// 	splitConfig.isDoorXCamCount = true;
-		// 	continue;
-		// }
 
 		switch (val) {
 		case "fade":
@@ -879,7 +863,6 @@ startup {
 		if (DEBUG_VARS_DUMP_SECONDS != 0 && (varsD.data.updateCounter % (DEBUG_VARS_DUMP_SECONDS * 60)) == 0) {
 			print(string.Format("MARIO POSITION: X:{0}, Y:{1}, Z:{2}", getPositionX(varsD, currentD), getPositionY(varsD, currentD), getPositionZ(varsD, currentD)));
 			print(varsToString(varsD));
-			print(string.Format("File A flags: {0:x}", getFileAFlags(varsD, currentD)));
 		}
 
 		varsD.data.updateCounter += 1;
@@ -923,8 +906,7 @@ startup {
 		if (
 			menuSelectedButtonID_old != menuSelectedButtonID_current &&
 			menuSelectedButtonID_old == 255 &&
-			0 <= menuSelectedButtonID_current &&
-			menuSelectedButtonID_current < 4 &&
+			0 <= menuSelectedButtonID_current && menuSelectedButtonID_current < 4 &&
 			(menuSelectedButtonID_current != 3 || !varsD.settings.disableAutoStartOnFileD) &&
 			menuClickPos_current == -10000
 		) {
@@ -1225,22 +1207,6 @@ startup {
 			isIn3DBox(varsD, currentD, doorBox) &&
 			optionalStarRequirementDone
 		);
-
-		// TODO(#6): AutoSplitter64 compatibility
-		// Door XCAM requires a little work.
-		// if (splitConfig.isDoorXCamCount && animation_old != animation_current) {
-		// 	bool isCurrentlyDoorXCam = DOOR_XCAM_COUNT_ACTIONS.Contains(animation_current);
-		//
-		// 	if (!splitConditions.doorXCamState && isCurrentlyDoorXCam) {
-		// 		splitConditions.doorXCamCount += 1;
-		//
-		// 		addImmediateSplittingCondition(
-		// 			splitConditions.doorXCamCount == splitConfig.doorXCamCountRequirement &&
-		// 			optionalStarRequirementDone
-		// 		);
-		// 	}
-		// 	splitConditions.doorXCamState = isCurrentlyDoorXCam;
-		// }
 
 		// Save stage id of last stage that was entered for castle movement condition.
 		if (isInStage) {


### PR DESCRIPTION
This release introduces the following bug fixes and new features:
- [breaking change] Moved run configuration from category name to first segment name. (eg. RTA mode becomes "[run-mode=rta]" in first segment name)
- [bugfix] Improve "immediate" and "fade" keywords to work for all types of splits.
- [new feature] Introduce "[run-mode=romhack]" to relax stage splitting (eg. for SM74 or SR).
- [new feature] Do not reset timer when resetting emulator when save file is not empty.
- [new feature] Add flag "final-star-grab" to wait on final star grab (eg. for Bingo)
